### PR TITLE
Remove unused parameter warning

### DIFF
--- a/ext/configure
+++ b/ext/configure
@@ -43,7 +43,7 @@ esac
 cat > Makefile <<EOF
 TARGET = io-watch
 CC = $CC
-CFLAGS = -Wall -Wextra
+CFLAGS = -Wall -Wextra -Werror
 LDFLAGS = $LDFLAGS
 SOURCES = $SOURCES
 OBJECTS = \$(SOURCES:.c=.o)

--- a/ext/io/watch/fsevent.c
+++ b/ext/io/watch/fsevent.c
@@ -44,6 +44,7 @@ void IO_Watch_FSEvent_callback(
 	const FSEventStreamEventFlags eventFlags[],
 	const FSEventStreamEventId eventIds[]) {
 	
+	(void)streamRef; // unused
 	const char **eventPaths = (const char**)eventData;
 	struct IO_Watch *watch = context;
 	


### PR DESCRIPTION
Remove a warning I saw while compiling the binary.

## Types of Changes

- Maintenance.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

I haven't added tests but I changed the `configure` script to generate a `Makefile` that sets `-Werror` in `CFLAGS`. Let me know if this isn't wanted.